### PR TITLE
ログイン周りの修正

### DIFF
--- a/db/migration/000001_init_schema.up.sql
+++ b/db/migration/000001_init_schema.up.sql
@@ -5,7 +5,7 @@ CREATE TABLE "users" (
 	"email" varchar UNIQUE NOT NULL,
 	"age" int NOT NULL,
 	"balance" bigint NOT NULL,
-	"password_changed_at" timestamptz NOT NULL DEFAULT '1970-01-01 00:00:00+00',
+	"password_changed_at" timestamptz NOT NULL DEFAULT (now()),
 	"created_at" timestamptz NOT NULL DEFAULT (now())
 );
 


### PR DESCRIPTION
## やったこと
* password_changed_atのデフォルトの時間をユーザー作成時に変更。
* responseにIDが抜けていたのを追加。
* 新規ユーザー作成時にEmailが被ってるかのチェックを追加。

## やってないこと

## この MR 後の課題
iOS アプリの方でログイン周りの UI 作成。。。

## そのほか
Closed #20 
